### PR TITLE
Update for Neovim 0.8+

### DIFF
--- a/lua/zf-native/health.lua
+++ b/lua/zf-native/health.lua
@@ -1,4 +1,4 @@
-local health = require("health")
+local health = vim.fn.has('nvim-0.8') and vim.health or require("health")
 local telescope = require("telescope")
 local zf = require("zf")
 


### PR DESCRIPTION
`require("health")` will be deprecated in 0.9 and shows a warning when running `:checkhealth` on 0.8