### PR TITLE
feat: luarocks/rocks.nvim support

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,31 @@
+---
+name: Push to Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+  pull_request: # Test luarocks install without publishing on PR
+  workflow_dispatch:
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v6
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            telescope.nvim
+          template: .github/workflows/rockspec.template

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+---
+permissions:
+  contents: write
+  pull-requests: write
+
+name: Release Please
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple
+          token: ${{ secrets.PAT }}

--- a/.github/workflows/rockspec.template
+++ b/.github/workflows/rockspec.template
@@ -1,0 +1,33 @@
+local git_ref = '$git_ref'
+local modrev = '$modrev'
+local specrev = '$specrev'
+
+local repo_url = '$repo_url'
+
+rockspec_format = '3.0'
+package = '$package'
+version = modrev ..'-'.. specrev
+
+description = {
+  summary = '$summary',
+  labels = $labels,
+  homepage = '$homepage',
+  $license
+}
+
+source = {
+  url = repo_url .. '/archive/' .. git_ref .. '.zip',
+  dir = '$repo_name-' .. '$archive_dir_suffix',
+}
+
+build = {
+  type = 'make',
+  build_pass = false,
+  install_variables = {
+    INST_PREFIX='$(PREFIX)',
+    INST_BINDIR='$(BINDIR)',
+    INST_LIBDIR='$(LIBDIR)',
+    INST_LUADIR='$(LUADIR)',
+    INST_CONFDIR='$(CONFDIR)',
+  },
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build:
+	echo "Do nothing"
+
+install:
+	mkdir -p $(INST_LUADIR)
+	mkdir -p $(INST_LIBDIR)
+	cp -r lua/* $(INST_LUADIR)
+	cp -r lib/* $(INST_LIBDIR)

--- a/lua/zf.lua
+++ b/lua/zf.lua
@@ -14,6 +14,10 @@ M.get_path = function()
         ext = "so"
     end
 
+    local libzf_path = package.searchpath(string.format("libzf-%s-%s", os, arch), package.cpath)
+    if libzf_path then
+        return libzf_path
+    end
     local dirname = string.sub(debug.getinfo(1).source, 2, #"/zf.lua" * -1)
     return dirname .. string.format("../lib/libzf-%s-%s.%s", os, arch, ext)
 end

--- a/telescope-zf-native.nvim-scm-1.rockspec
+++ b/telescope-zf-native.nvim-scm-1.rockspec
@@ -1,0 +1,39 @@
+local MODREV, SPECREV = 'scm', '-1'
+rockspec_format = '3.0'
+package = 'telescope-zf-native.nvim'
+version = MODREV .. SPECREV
+
+description = {
+  summary = 'native telescope bindings to zf for sorting results',
+  labels = { 'neovim', 'plugin', 'telescope', 'zf' },
+  homepage = 'https://github.com/natecraddock/telescope-zf-native.nvim',
+  license = 'MIT',
+}
+
+dependencies = {
+  'lua >= 5.1',
+  'telescope.nvim',
+}
+
+source = {
+  url = 'https://github.com/natecraddock/telescope-zf-native.nvim/archive/refs/tags/' .. MODREV .. '.zip',
+  dir = 'telescope-fzf-native.nvim-' .. MODREV
+}
+
+if MODREV == 'scm' then
+  source = {
+    url = 'git://github.com/natecraddock/telescope-zf-native.nvim',
+  }
+end
+
+build = {
+  type = 'make',
+  build_pass = false,
+  install_variables = {
+    INST_PREFIX='$(PREFIX)',
+    INST_BINDIR='$(BINDIR)',
+    INST_LIBDIR='$(LIBDIR)',
+    INST_LUADIR='$(LUADIR)',
+    INST_CONFDIR='$(CONFDIR)',
+  },
+}


### PR DESCRIPTION
Hey :wave: 

### Summary

This PR is part of a push to get neovim plugins on [luarocks.org](https://luarocks.org/labels/neovim).

See also:

- [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.
- [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html).

With luarocks/rocks.nvim, it is [the plugin authors' responsibility to declare dependencies - not the user's](https://github.com/nvim-neorocks/rocks.nvim?tab=readme-ov-file#grey_question-why-rocksnvim).
Installing this plugin becomes as simple as `:Rocks install telescope-zf-native.nvim`.

### Things done:

- Add a workflow that publishes tags to luarocks.org when a tag or release is pushed.
- Add a release-please workflow that creates release PRs with SemVer versioning based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

The workflows are based on [this guide](https://github.com/nvim-neorocks/sample-luarocks-plugin)

### Notes:

> [!IMPORTANT]
> 
> - **For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)**.

- On each merge to `master` (if this lands on `master`), the `release-please` workflow creates (or updates an existing) release PR.
- You decide when to merge release PRs.
  Doing so will result in a SemVer tag, a changelog update, and a GitHub release, which will trigger the `luarocks` workflow.
  If you would like versioning to start from a specific version (e.g. 2.0.0), you can [configure this with a manifest](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md).
- Tagged releases are installed locally and then published to luarocks.org.
  - If you push tags from a local checkout, the workflow is triggered automatically.
  - If you use GitHub releases to create tags, you may need to [add a PA token](https://github.com/nvim-neorocks/sample-luarocks-plugin?tab=readme-ov-file#generating-a-pat-personal-access-token) for the workflow to be triggered automatically.
- Due to a shortcoming in luarocks.org (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the luarocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.